### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Gradle Build
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rahulsom/jansi-table/security/code-scanning/1](https://github.com/rahulsom/jansi-table/security/code-scanning/1)

To fix this issue, you should add a `permissions` block at the top level of your workflow file (`.github/workflows/build.yml`). This block should specify the minimum privileges needed—usually `contents: read` is safe as a baseline, plus any others required by the workflow or reusable workflows. If you are unsure what permissions are needed (since the actual workflow is a reusable one), set only `contents: read` to limit access, and adjust further if you discover that more permissions are needed through test runs or workflow documentation. The change should go after the workflow `name:` and before `on:`, or at the top level (outside jobs). Only add or update the `permissions` block and do not change any existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
